### PR TITLE
search settings for getting server

### DIFF
--- a/src/Minehut.ts
+++ b/src/Minehut.ts
@@ -1,4 +1,4 @@
-import { MINEHUT_API_BASE } from './constants';
+import { DEV_MINEHUT_API_BASE, MINEHUT_API_BASE } from './constants';
 import { ServerManager } from './server/ServerManager';
 import { IconManager } from './icon/IconManager';
 import { PluginManager } from './plugin/PluginManager';
@@ -9,18 +9,18 @@ import { PlayerDistributionResponse } from './stats/PlayerDistributionResponse';
 import { AddonManager } from './addon/AddonManager';
 
 export class Minehut {
-	session: null; // Session in the future
-	user: null; // User/ClientUser in the future
-
+	
 	icons: IconManager;
 	servers: ServerManager;
 	plugins: PluginManager;
 	addons: AddonManager;
 
 	API_BASE: string;
+	DEV_API_BASE: string;
 
 	constructor() {
 		this.API_BASE = MINEHUT_API_BASE;
+		this.DEV_API_BASE = DEV_MINEHUT_API_BASE;
 
 		this.icons = new IconManager(this);
 		this.servers = new ServerManager(this);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
 export const MINEHUT_API_BASE = 'https://api.minehut.com';
+export const DEV_MINEHUT_API_BASE = 'https://api.dev.minehut.com';
 export const MARKET_PRODUCTS_ENDPOINT =
 	'https://facade-service-prod.superleague.com/facade/v1/client/products';
 

--- a/src/example.ts
+++ b/src/example.ts
@@ -2,8 +2,11 @@ import { Minehut } from './Minehut';
 
 (async function () {
 	const minehut = new Minehut();
-	const server = await minehut.servers.get('dangerZONE', true);
+	const server = await minehut.servers.get('dangerZONE', { byName: true });
 	console.log(server);
+
+	const devServer = await minehut.servers.get('test256', { byName: true, dev: true });
+	console.log(devServer);
 
 	const icon = await server.getActiveIcon();
 	console.log(`active icon ${JSON.stringify(icon)}`);

--- a/src/server/ServerManager.ts
+++ b/src/server/ServerManager.ts
@@ -10,9 +10,9 @@ export class ServerManager {
 		this.client = client;
 	}
 
-	async get(server: string, byName: boolean = true) {
+	async get(server: string, query: ServerSearchSettings) {
 		const res = await fetch(
-			`${this.client.API_BASE}/server/${server}${byName ? '?byName=true' : ''}`
+			`${query.dev ? this.client.DEV_API_BASE : this.client.API_BASE}/server/${server}${query.byName ? '?byName=true' : ''}`
 		);
 		// The Minehut API returns 502 for unknown servers (???)
 		if (!res.ok) throw new Error(res.statusText);
@@ -20,4 +20,9 @@ export class ServerManager {
 		const srv: ServerResponse = json.server;
 		return new Server(srv, this.client);
 	}
+}
+
+export interface ServerSearchSettings {
+	byName?: boolean;
+	dev?: boolean;
 }


### PR DESCRIPTION
This PR adds 2 different search settings `minehut.servers.get` method. One for if the search should be by name and the other for if it should get the server from the dev api.

### Example
```
minehut.servers.get('test256', { byName: true, dev: true });
```