### PR TITLE
search settings for getting server

### DIFF
--- a/src/Minehut.ts
+++ b/src/Minehut.ts
@@ -1,4 +1,4 @@
-import { MINEHUT_API_BASE } from './constants';
+import { DEV_MINEHUT_API_BASE, MINEHUT_API_BASE } from './constants';
 import { ServerManager } from './server/ServerManager';
 import { IconManager } from './icon/IconManager';
 import { PluginManager } from './plugin/PluginManager';
@@ -9,8 +9,6 @@ import { PlayerDistributionResponse } from './stats/PlayerDistributionResponse';
 import { AddonManager } from './addon/AddonManager';
 
 export class Minehut {
-	session: null; // Session in the future
-	user: null; // User/ClientUser in the future
 
 	icons: IconManager;
 	servers: ServerManager;
@@ -19,8 +17,12 @@ export class Minehut {
 
 	API_BASE: string;
 
-	constructor() {
-		this.API_BASE = MINEHUT_API_BASE;
+	constructor(settings: MinehutSettings = { dev: false }) {
+		if(settings.dev) {
+			this.API_BASE = DEV_MINEHUT_API_BASE
+		}else {
+			this.API_BASE = MINEHUT_API_BASE
+		}
 
 		this.icons = new IconManager(this);
 		this.servers = new ServerManager(this);
@@ -59,4 +61,8 @@ export class Minehut {
 			},
 		};
 	}
+}
+
+export interface MinehutSettings {
+	dev?: boolean;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
 export const MINEHUT_API_BASE = 'https://api.minehut.com';
+export const DEV_MINEHUT_API_BASE = 'https://api.dev.minehut.com';
 export const MARKET_PRODUCTS_ENDPOINT =
 	'https://facade-service-prod.superleague.com/facade/v1/client/products';
 

--- a/src/example.ts
+++ b/src/example.ts
@@ -5,6 +5,10 @@ import { Minehut } from './Minehut';
 	const server = await minehut.servers.get('dangerZONE', true);
 	console.log(server);
 
+	const devMinehut = new Minehut({ dev: true });
+	const devServer = await devMinehut.servers.get('test256', true);
+	console.log(devServer);
+
 	const icon = await server.getActiveIcon();
 	console.log(`active icon ${JSON.stringify(icon)}`);
 


### PR DESCRIPTION
This PR adds an option into the Minehut class to interact with the dev api

### Example
```ts
const devMinehut = new Minehut({ dev: true });
const devServer = await devMinehut.servers.get('test256', true);
console.log(devServer);
```

this is an updated version of #6 